### PR TITLE
fixed typos for left/right zones

### DIFF
--- a/examples/X_NUCLEO_53L1A1_People_Counting/X_NUCLEO_53L1A1_People_Counting.ino
+++ b/examples/X_NUCLEO_53L1A1_People_Counting/X_NUCLEO_53L1A1_People_Counting.ino
@@ -108,7 +108,7 @@
 #define BACK_ZONE_CENTER                             239
 #elif ROWS_OF_SPADS == 8
 #define FRONT_ZONE_CENTER                            175 // was 167, see UM2555 on st.com, centre = 175 has better return signal rate for the ROI #1
-#define BACK_ZONE_CENTER                             231 
+#define BACK_ZONE_CENTER                             231
 #endif
 
 int PplCounter = 0;
@@ -198,16 +198,16 @@ int ProcessPeopleCountingData(int16_t Distance, uint8_t zone, uint8_t RangeStatu
     }
   } else // right zone
   {
-    
+
     if (CurrentZoneStatus != RightPreviousStatus)
     {
-      // event in left zone has occured
+      // event in right zone has occured
       AnEventHasOccured = 1;
       if (CurrentZoneStatus == SOMEONE)
       {
         AllZonesCurrentStatus += 2;
       }
-      // need to left right zone as well ...
+      // need to check left zone as well ...
       if (LeftPreviousStatus == SOMEONE)
       {
         // event in left zone has occured
@@ -217,7 +217,7 @@ int ProcessPeopleCountingData(int16_t Distance, uint8_t zone, uint8_t RangeStatu
       RightPreviousStatus = CurrentZoneStatus;
     }
   }
-  
+
 #ifdef TRACE_PPC
   // print debug data only when someone is within the field of view
   trace_count++;


### PR DESCRIPTION
Hi! I went through the code and have a question concerning timing. If I understand well after an entry or exit has been detected the 10x2 Table is cleared and we must fill it up + wait for 4 news events before taking a new decision.

The Timing budget is set to 33ms and there seems to be 33ms also between two distance measures. 

Am I correct to say that the minimum delay between two consecutive entry/exit is : (10+4)*2*(33+33) = 1848ms ?

This seems like a pretty large delay. 

Thanks,
Q.